### PR TITLE
Add cache repository suffix

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -46,6 +46,9 @@ inputs:
   build_extra_args:
     description: "(Optional) Extra arguments to pass to docker build"
     required: false
+  cache_repository_suffix:
+    description: "(Optional) Specify cache repository (default: <image_name>-stages)"
+    required: false
 
 outputs:
   FULL_IMAGE_NAME:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -119,7 +119,7 @@ _push_image_stages() {
   local stage_image
   for stage in $(_get_stages); do
     echo -e "\nPushing stage: $stage_number"
-    stage_image=$(_get_full_image_name)-stages:$stage_number
+    stage_image=$(_get_full_image_name)${INPUT_CACHE_REPOSITORY_SUFFIX}-stages:$stage_number
     docker tag "$stage" "$stage_image"
     docker push "$stage_image"
     stage_number=$(( stage_number+1 ))
@@ -127,7 +127,7 @@ _push_image_stages() {
 
   # push the image itself as a stage (the last one)
   echo -e "\nPushing stage: $stage_number"
-  stage_image=$(_get_full_image_name)-stages:$stage_number
+  stage_image=$(_get_full_image_name)${INPUT_CACHE_REPOSITORY_SUFFIX}-stages:$stage_number
   docker tag "$DUMMY_IMAGE_NAME" "$stage_image"
   docker push "$stage_image"
 }
@@ -146,7 +146,7 @@ _login_to_aws_ecr() {
 
 _create_aws_ecr_repos() {
   _aws ecr create-repository --repository-name "$INPUT_IMAGE_NAME" 2>&1 | grep -v RepositoryAlreadyExistsException
-  _aws ecr create-repository --repository-name "$INPUT_IMAGE_NAME"-stages 2>&1 | grep -v RepositoryAlreadyExistsException
+  _aws ecr create-repository --repository-name "$INPUT_IMAGE_NAME"${INPUT_CACHE_REPOSITORY_SUFFIX}-stages 2>&1 | grep -v RepositoryAlreadyExistsException
   return 0
 }
 
@@ -198,7 +198,7 @@ pull_cached_stages() {
     return
   fi
   echo -e "\n[Action Step] Pulling image..."
-  docker pull --all-tags "$(_get_full_image_name)"-stages | tee "$PULL_STAGES_LOG" || true
+  docker pull --all-tags "$(_get_full_image_name)"${INPUT_CACHE_REPOSITORY_SUFFIX}-stages | tee "$PULL_STAGES_LOG" || true
 }
 
 build_image() {
@@ -207,7 +207,7 @@ build_image() {
 
   # create param to use (multiple) --cache-from options
   if [ "$max_stage" ]; then
-    cache_from=$(eval "echo --cache-from=$(_get_full_image_name)-stages:{1..$max_stage}")
+    cache_from=$(eval "echo --cache-from=$(_get_full_image_name)${INPUT_CACHE_REPOSITORY_SUFFIX}-stages:{1..$max_stage}")
     echo "Use cache: $cache_from"
   fi
 

--- a/readme.md
+++ b/readme.md
@@ -32,6 +32,8 @@ Built-in support for the most known registries: Docker Hub, AWS ECR, GitHub's re
 
 - **pull_image_and_stages**: Set to `false` to avoid pulling from the registry or to build from scratch (default: `true`).
 
+- **cache_repository_suffix**: Specify cache repository (default: <image_name>-stages).
+
 - **build_extra_args**: Extra params for `docker build` (e.g. `"--build-arg=hello=world"`).
 
 - **push_image_and_stages**: Test a command before pushing. Use `false` to not push at all (default: `true`).
@@ -45,7 +47,7 @@ Built-in support for the most known registries: Docker Hub, AWS ECR, GitHub's re
 
 ## Outputs
 
-- **FULL_IMAGE_NAME**: Full name of the Docker Image with the Registry (if provided) and Namespace included.  
+- **FULL_IMAGE_NAME**: Full name of the Docker Image with the Registry (if provided) and Namespace included.
 e.g.: `docker.pkg.github.com/whoan/hello-world/hello-world`
 
 ## How it works


### PR DESCRIPTION
Add `cache_repository_suffix` to allow matrix builds to have separate caches